### PR TITLE
build(ci): update CentOS base image to version 8

### DIFF
--- a/dockerfiles/release-ci.DockerFile
+++ b/dockerfiles/release-ci.DockerFile
@@ -1,7 +1,11 @@
-FROM centos:centos7 
+FROM centos:centos8
 
-RUN yum install -y centos-release-scl epel-release \
+RUN cd /etc/yum.repos.d/ \
+    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     && yum update -y \
+    && yum install -y dnf-plugins-core \
+    && yum config-manager --set-enabled powertools \
     && yum clean all
 
 RUN yum install -y \


### PR DESCRIPTION
Update the CI Dockerfile to use CentOS 8 instead of CentOS 7. This change includes updating the yum repositories to use vault.centos.org and enabling the powertools repository for additional package availability.

The update is reflected in the FROM statement and the associated yum configuration changes within the Dockerfile.
fix #75 
I have read the CLA Document and I hereby sign the CLA

